### PR TITLE
IPython Shell

### DIFF
--- a/.ipython.py
+++ b/.ipython.py
@@ -1,0 +1,14 @@
+# Reynir configuration file for ipython.
+
+from platform import python_version, python_implementation
+
+c.TerminalInteractiveShell.confirm_exit = False
+c.InteractiveShellApp.exec_PYTHONSTARTUP = False
+
+c.InteractiveShell.banner1 = "Python %s (%s)" % (python_version(), python_implementation())
+c.InteractiveShell.banner2 = 'Welcome to the Greynir iPython shell!\n'
+
+c.InteractiveShellApp.exec_lines = [
+    'from scraperdb import *',
+    's = SessionContext(commit=True).__enter__()',
+]

--- a/.ipython.py
+++ b/.ipython.py
@@ -6,9 +6,11 @@ c.TerminalInteractiveShell.confirm_exit = False
 c.InteractiveShellApp.exec_PYTHONSTARTUP = False
 
 c.InteractiveShell.banner1 = "Python %s (%s)" % (python_version(), python_implementation())
-c.InteractiveShell.banner2 = 'Welcome to the Greynir iPython shell!\n'
+c.InteractiveShell.banner2 = 'Welcome to the Greynir IPython shell!\n'
+
+c.InteractiveShellApp.extensions = ['autoreload']
 
 c.InteractiveShellApp.exec_lines = [
     'from scraperdb import *',
-    's = SessionContext(commit=True).__enter__()',
+    's = SessionContext(commit=False).__enter__()',
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ psycopg2cffi==2.8.1
 requests==2.20.0
 reynir>=1.2.3
 SQLAlchemy==1.2.12
+ipython>=7.0

--- a/shell.sh
+++ b/shell.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# Start IPython shell using config stored in repository
+#
+
+if [ -z "$VIRTUAL_ENV" ]; then
+	echo "Not running in a virtualenv"
+  	exit
+fi
+
+VENV_DIR="`basename \"$VIRTUAL_ENV\"`"
+
+if [ ! -d "$VENV_DIR" ]; then
+	echo "virtualenv directory '${VENV_DIR}' not found"
+	exit
+fi
+
+IPYTHON_BIN="${VENV_DIR}/bin/ipython3"
+
+if [ ! -e "$IPYTHON_BIN" ]; then
+	echo "iPython binary not found: '${IPYTHON_BIN}'"
+	exit
+fi
+
+IPYTHON_CONFIG=".ipython.py"
+
+$IPYTHON_BIN --config=$IPYTHON_CONFIG --pprint --no-simple-prompt


### PR DESCRIPTION
Run ./shell.sh from repo root to launch an IPython shell, vastly superior to the standard Python REPL. Features include syntax highlighting, auto-pretty-printing, auto-indentation, smart autocompletion, smart persistent history across sessions, easy timing of functions, integrated access to pdb and the profiler, various introspection tools etc.

Auto-reloading of modules prior to every command can be enabled by typing '%autoreload 2'

I've configured the shell to automatically import the database models and create a (commit-disabled) database session when launched. We can set it up to auto-import anything we want by mucking around with the .ipython.py config file. Local user settings can be configured in ~/.ipython/profile_default.

See https://ipython.readthedocs.io/en/stable/ for details.

