### PR TITLE
Image for persons in onhover box

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -33,7 +33,7 @@ cp config/TnT-model.pickle $DEST/config/TnT-model.pickle
 
 cp article.py $DEST/article.py
 cp fetcher.py $DEST/fetcher.py
-cp getimage.py $DEST/getimage.py
+cp images.py $DEST/images.py
 cp incparser.py $DEST/incparser.py
 cp main.py $DEST/main.py
 cp nertokenizer.py $DEST/nertokenizer.py

--- a/images.py
+++ b/images.py
@@ -110,6 +110,9 @@ def get_image_url(name, size="large", thumb=False, enclosing_session=None, from_
                 num = _NUM_IMG_URLS,
                 start = 1,
                 imgSize = size,
+                imgType = "face",   # Only images with faces
+                lr = "lang_is",     # Higher priority for Icelandic language pages
+                gl = "is",          # Higher priority for .is results
                 searchType = "image",
                 cx = _CX,
                 key = _API_KEY

--- a/main.py
+++ b/main.py
@@ -836,10 +836,13 @@ def image():
     resp = dict(found=False)
 
     name = request.args.get("name", "")
-    thumb = int(request.args.get("thumb", 0))
+    try:
+        thumb = int(request.args.get("thumb", 0))
+    except:
+        thumb = 0
 
     if name:
-        img = get_image_url(name, thumb=thumb)
+        img = get_image_url(name, thumb=thumb, cache_only=True)
         if img:
             resp['found'] = True
             resp['image'] = img

--- a/main.py
+++ b/main.py
@@ -67,7 +67,7 @@ from scraperdb import (
 )
 from query import Query
 from search import Search
-from getimage import get_image_url, update_broken_image_url, blacklist_image_url
+from images import get_image_url, update_broken_image_url, blacklist_image_url
 from tnttagger import ifd_tag
 
 
@@ -828,6 +828,24 @@ def reportimage():
             resp["found_new"] = True
 
     return better_jsonify(**resp)
+
+
+@app.route("/image", methods=["GET"])
+def image():
+    """ Get image for name """
+    resp = dict(found=False)
+
+    name = request.args.get("name", "")
+    thumb = int(request.args.get("thumb", 0))
+
+    if name:
+        img = get_image_url(name, thumb=thumb)
+        if img:
+            resp['found'] = True
+            resp['image'] = img
+
+    return better_jsonify(**resp)
+
 
 @app.route("/genders", methods=["GET"])
 @max_age(seconds=5 * 60)

--- a/static/css/main-bootstrap.css
+++ b/static/css/main-bootstrap.css
@@ -656,11 +656,12 @@ div#info #details {
 }
 
 div#info-image {
-   max-width:100%;
+   max-width: 100%;
 }
 
 div#info-image img {
-   max-width:100%;
+   width: 100%;
+   margin-bottom: 5px;
 }
 
 #meta-author, #meta-timestamp, #meta-url {

--- a/static/css/main-bootstrap.css
+++ b/static/css/main-bootstrap.css
@@ -655,6 +655,14 @@ div#info #details {
    font-style: italic;
 }
 
+div#info-image {
+   max-width:100%;
+}
+
+div#info-image img {
+   max-width:100%;
+}
+
 #meta-author, #meta-timestamp, #meta-url {
    text-align: right;
 }

--- a/static/js/page.js
+++ b/static/js/page.js
@@ -144,15 +144,16 @@ function showEntity(ev) {
 function hoverIn() {
    // Hovering over a token
    var wId = $(this).attr("id");
-   if (wId === null || wId === undefined)
+   if (wId === null || wId === undefined) {
       // No id: nothing to do
       return;
+   }
    var ix = parseInt(wId.slice(1));
    var t = w[ix];
-   if (!t)
+   if (!t) {
       // No token: nothing to do
       return;
-
+   }
    // Save our position
    var offset = $(this).position();
    // Highlight the token
@@ -160,23 +161,36 @@ function hoverIn() {
 
    var r = tokenInfo(t, nameDict);
 
-   if (!r.grammar && !r.lemma && !r.details)
+   if (!r.grammar && !r.lemma && !r.details) {
       // Nothing interesting to show (probably the sentence didn't parse)
       return;
+   }
 
    $("#grammar").html(r.grammar || "");
    $("#lemma").text(r.lemma || "");
    $("#details").text(r.details || "");
 
    // Display the percentage bar if we have percentage info
-   if (r.percent !== null)
+   if (r.percent !== null) {
       makePercentGraph(r.percent);
-   else
+   } else {
       $("#percent").css("display", "none");
+   }
 
    $("#info").removeClass();
-   if (r.class !== null)
+   if (r.class !== null) {
       $("#info").addClass(r.class);
+   }
+
+   if (t.k == TOK_PERSON && t.v.split(' ').length > 1) {
+      console.log(t);
+      console.log(t.v.split(' '))
+      getImage(r.lemma, function(img) {
+         $("#info-image").html(
+            $("<img>").attr('src', img[0])
+         ).show();
+      })
+   }
 
    $("#info span#tag")
       .removeClass()
@@ -190,18 +204,36 @@ function hoverIn() {
       .css("visibility", "visible");
 }
 
+function getImage(name, successFunc) {
+   if (!getImage.imageCache) {
+      getImage.imageCache = {};
+   }
+   if (getImage.imageCache[name]) {
+      successFunc(getImage.imageCache[name]);
+   }
+   $.getJSON("/image?thumb=1&name=" + encodeURI(name), function(resp) {
+      if (resp['found']) {
+         getImage.imageCache[name] = resp['image'];
+         successFunc(resp['image'])
+      }
+   });
+}
+
 function hoverOut() {
    // Stop hovering over a word
    $("#info").css("visibility", "hidden");
+   $("#info-image").hide();
    $(this).removeClass("highlight");
    var wId = $(this).attr("id");
-   if (wId === null || wId === undefined)
+   if (wId === null || wId === undefined) {
       // No id: nothing more to do
       return;
+   }
    var ix = parseInt(wId.slice(1));
    var t = w[ix];
-   if (!t)
-      return;
+   if (!t) {
+      return; // ??
+   }
 }
 
 function displayTokens(j) {

--- a/static/js/page.js
+++ b/static/js/page.js
@@ -206,12 +206,10 @@ function hoverIn() {
 
 function getImage(name, successFunc) {
    var cache = getImage.imageCache;
-
    if (cache === undefined) {
       cache = {};
       getImage.imageCache = cache;
    }
-
    // Retrieve from cache
    if (cache[name] !== undefined) {
       if (cache[name].length) {
@@ -224,11 +222,12 @@ function getImage(name, successFunc) {
       getImage.request.abort();
    }
    // Ask server for thumbnail image
-   getImage.request = $.getJSON("/image?thumb=1&name=" + encodeURI(name), function(resp) {
+   var enc = encodeURIComponent(name)
+   getImage.request = $.getJSON("/image?thumb=1&name=" + enc, function(r) {
       cache[name] = [];
-      if (resp['found']) {
-         cache[name] = resp['image'];
-         successFunc(resp['image']);
+      if (r['found']) {
+         cache[name] = r['image'];
+         successFunc(r['image']);
       }
    });
 }
@@ -238,16 +237,6 @@ function hoverOut() {
    $("#info").css("visibility", "hidden");
    $("#info-image").hide();
    $(this).removeClass("highlight");
-   // var wId = $(this).attr("id");
-   // if (wId === null || wId === undefined) {
-   //    // No id: nothing more to do
-   //    return;
-   // }
-   // var ix = parseInt(wId.slice(1));
-   // var t = w[ix];
-   // if (!t) {
-   //    return; // ??
-   // }
 }
 
 function displayTokens(j) {

--- a/static/js/page.js
+++ b/static/js/page.js
@@ -118,11 +118,13 @@ function showPerson(ev) {
    if (wId !== undefined) {
       // Obtain the name in nominative case from the token
       var ix = parseInt(wId.slice(1));
-      if (w[ix] !== undefined)
+      if (w[ix] !== undefined) {
          name = w[ix].v;
+      }
    }
-   if (name === undefined)
+   if (name === undefined) {
       name = $(this).text(); // No associated token: use the contained text
+   }
    queryPerson(name);
    ev.stopPropagation();
 }
@@ -228,7 +230,6 @@ function getImage(name, successFunc) {
          cache[name] = resp['image'];
          successFunc(resp['image']);
       }
-      getImage.request = null;
    });
 }
 
@@ -237,16 +238,16 @@ function hoverOut() {
    $("#info").css("visibility", "hidden");
    $("#info-image").hide();
    $(this).removeClass("highlight");
-   var wId = $(this).attr("id");
-   if (wId === null || wId === undefined) {
-      // No id: nothing more to do
-      return;
-   }
-   var ix = parseInt(wId.slice(1));
-   var t = w[ix];
-   if (!t) {
-      return; // ??
-   }
+   // var wId = $(this).attr("id");
+   // if (wId === null || wId === undefined) {
+   //    // No id: nothing more to do
+   //    return;
+   // }
+   // var ix = parseInt(wId.slice(1));
+   // var t = w[ix];
+   // if (!t) {
+   //    return; // ??
+   // }
 }
 
 function displayTokens(j) {

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -37,24 +37,7 @@
 
    <h3 class="help">Málgreining <small>Smelltu á málsgrein til að sjá trjágreiningu hennar</small></h3>
 
-   <!-- Popup with info about the word being hovered over -->
-   <div id="info">
-      <table>
-      <tr>
-      <td><span id="tag" class='glyphicon glyphicon-tag'></span></td>
-      <td id="lemma"></td>
-      </tr>
-      </table>
-      <p id="details"></p>
-      <p id="grammar"></p>
-      <div id="percent" class="progress">
-         <div class="progress-bar progress-bar-info" role="progressbar"
-            aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%">
-            <span class="sr-only">0%</span>
-         </div>
-      </div>
-      <div id="info-image"></div>
-   </div>
+   <{% include 'hover-infobox.html' %}
 
    <div id="result">
    </div>

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -53,6 +53,7 @@
             <span class="sr-only">0%</span>
          </div>
       </div>
+      <div id="info-image"></div>
    </div>
 
    <div id="result">

--- a/templates/hover-infobox.html
+++ b/templates/hover-infobox.html
@@ -1,0 +1,23 @@
+
+<!-- Popup with info about the word being hovered over -->
+<div id="info">
+	<table>
+		<tr>
+      		<td><span id="tag" class='glyphicon glyphicon-tag'></span></td>
+      		<td id="lemma"></td>
+  		</tr>
+  	</table>
+	
+	<p id="details"></p>
+	
+	<p id="grammar"></p>
+
+	<div id="percent" class="progress">
+		<div class="progress-bar progress-bar-info" role="progressbar"
+		    aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%">
+			<span class="sr-only">0%</span>
+		</div>
+	</div>
+
+	<div id="info-image"></div>
+</div>

--- a/templates/page.html
+++ b/templates/page.html
@@ -33,24 +33,7 @@
 
 <div id="output">
 
-   <!-- Popup with info about the word being hovered over -->
-   <div id="info">
-      <table>
-      <tr>
-      <td><span id="tag" class='glyphicon glyphicon-tag'></span></td>
-      <td id="lemma"></td>
-      </tr>
-      </table>
-      <p id="details"></p>
-      <p id="grammar"></p>
-      <div id="percent" class="progress">
-         <div class="progress-bar progress-bar-info" role="progressbar"
-            aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%">
-            <span class="sr-only">0%</span>
-         </div>
-      </div>
-      <div id="info-image"></div>
-   </div>
+   {% include 'hover-infobox.html' %}
 
    <div id="column">
       <!-- Article heading and content -->

--- a/templates/page.html
+++ b/templates/page.html
@@ -49,6 +49,7 @@
             <span class="sr-only">0%</span>
          </div>
       </div>
+      <div id="info-image"></div>
    </div>
 
    <div id="column">

--- a/templates/treegrid.html
+++ b/templates/treegrid.html
@@ -424,23 +424,7 @@
    </div>
 </div>
 
-<!-- Popup with info about a terminal that is being hovered over -->
-<div id="info">
-   <table>
-   <tr>
-   <td><span id="tag" class='glyphicon glyphicon-tag'></span></td>
-   <td id="lemma"></td>
-   </tr>
-   </table>
-   <p id="details"></p>
-   <p id="grammar"></p>
-   <div id="percent" class="progress">
-      <div class="progress-bar progress-bar-info" role="progressbar"
-         aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%">
-         <span class="sr-only">0%</span>
-      </div>
-   </div>
-</div>
+{% include 'hover-infobox.html' %}
 
 {%- endif %}
 


### PR DESCRIPTION
Fetch thumbnail image for persons in word onhover box. For now, I've set it to only show an image if an image URL exists in the cache (i.e. no Google API calls are triggered on hover). We can change this later if we want, but let's first see how this turns out.

Also, image search now prioritises results on Icelandic-language pages and servers with an Icelandic geolocation.